### PR TITLE
create two branches on first createBranch

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -239,6 +239,15 @@ export const instance = vue
 						? this.selected
 						: tree.rightmostNode()?.id;
 
+				if (tree.isLeafNode(parentNodeId)){
+					const newNodeId = tree.addNodeAfter(parentNodeId, true);
+					if (newNodeId === null) {
+						return alert(
+							'You must select a node to perform this action; if there are no nodes then try creating a new tree. If this issue persists, please contact an instructor.'
+						);
+					}
+				} 
+				
 				const newNodeId = tree.addNodeAfter(parentNodeId, true);
 				if (newNodeId === null) {
 					return alert(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -239,15 +239,15 @@ export const instance = vue
 						? this.selected
 						: tree.rightmostNode()?.id;
 
-				if (tree.isLeafNode(parentNodeId)){
+				if (tree.isLeafNode(parentNodeId)) {
 					const newNodeId = tree.addNodeAfter(parentNodeId, true);
 					if (newNodeId === null) {
 						return alert(
 							'You must select a node to perform this action; if there are no nodes then try creating a new tree. If this issue persists, please contact an instructor.'
 						);
 					}
-				} 
-				
+				}
+
 				const newNodeId = tree.addNodeAfter(parentNodeId, true);
 				if (newNodeId === null) {
 					return alert(

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -1250,12 +1250,12 @@ export class TruthTree {
 	 * Determines whether current node is a leaf node. A leaf node has no
 	 * children
 	 * @param root the id of the root of the subtree
-	 * @returns true if root is leaf node, false otherwise 
+	 * @returns true if root is leaf node, false otherwise
 	 */
 	isLeafNode(root: number | null): boolean {
 		let node = this.getNode(root);
-		if (node === null){
-			return false
+		if (node === null) {
+			return false;
 		}
 		return node.children.length === 0;
 	}

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -110,7 +110,6 @@ export class TruthTreeNode {
 
 	parent: number | null = null;
 	children: number[] = [];
-	branchNode: number | null = null;
 
 	antecedent: number | null = null;
 	decomposition: Set<number> = new Set();
@@ -139,7 +138,6 @@ export class TruthTreeNode {
 		newNode.premise = this.premise;
 		newNode.comment = this.comment;
 		newNode.parent = this.parent;
-		newNode.branchNode = this.branchNode;
 		newNode.children = [...this.children];
 		newNode.antecedent = this.antecedent;
 		newNode.decomposition = new Set(this.decomposition);

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -110,6 +110,7 @@ export class TruthTreeNode {
 
 	parent: number | null = null;
 	children: number[] = [];
+	branchNode: number | null = null;
 
 	antecedent: number | null = null;
 	decomposition: Set<number> = new Set();
@@ -138,6 +139,7 @@ export class TruthTreeNode {
 		newNode.premise = this.premise;
 		newNode.comment = this.comment;
 		newNode.parent = this.parent;
+		newNode.branchNode = this.branchNode;
 		newNode.children = [...this.children];
 		newNode.antecedent = this.antecedent;
 		newNode.decomposition = new Set(this.decomposition);
@@ -1247,12 +1249,26 @@ export class TruthTree {
 	}
 
 	/**
+	 * Determines whether current node is a leaf node. A leaf node has no
+	 * children
+	 * @param root the id of the root of the subtree
+	 * @returns true if root is leaf node, false otherwise 
+	 */
+	isLeafNode(root: number | null): boolean {
+		let node = this.getNode(root);
+		if (node === null){
+			return false
+		}
+		return node.children.length === 0;
+	}
+
+	/**
 	 * Returns the leftmost node in the subtree rooted at a given node, or the
 	 * entire tree if no node is specified.
 	 * @param root the id of the root of the subtree
 	 * @returns the leftmost node
 	 */
-	leftmostNode(root?: number | null) {
+	leftmostNode(root?: number | null): TruthTreeNode | null {
 		let node =
 			typeof root === 'number' ? this.getNode(root) : this.getNode(this.root);
 		if (node === null) {
@@ -1273,7 +1289,7 @@ export class TruthTree {
 	 * @param root the id of the root of the subtree
 	 * @returns the rightmost node
 	 */
-	rightmostNode(root?: number | null) {
+	rightmostNode(root?: number | null): TruthTreeNode | null {
 		let node =
 			typeof root === 'number' ? this.getNode(root) : this.getNode(this.root);
 		if (node === null) {


### PR DESCRIPTION
Two branches are created on first branch creation. Additional calls to create branch only adds one branch

![willowBranch](https://user-images.githubusercontent.com/29582421/227397647-b74b8df0-215e-47eb-9bf9-de31f28ba706.jpg)

Before: Would need to call create branch twice
After: Only one call to create branch needed

![willowOddBranch](https://user-images.githubusercontent.com/29582421/227397756-fc8f87aa-fd17-4a7b-822d-7e09ab4b100f.jpg)
It is still possible to create an odd number of branches. Subsequent calls to createBranch will have only add one extra branch
