### PR TITLE
Add atom branch GUI + Logic

### DIFF
--- a/src/client/component/truth-tree-branch.ts
+++ b/src/client/component/truth-tree-branch.ts
@@ -226,7 +226,11 @@ export const TruthTreeBranchComponent = defineComponent({
 								selectedNode.decomposition.has(id) &&
 								selectedNode.isClosedTerminator(),
 						}">
-          <truth-tree-node :id="id"></truth-tree-node>
+		  <truth-tree-node :id="id"></truth-tree-node>
+		  <select v-if="tree.nodes[id].children.length > 1" @click.stop="" name="membership" id="membership">
+		    <option value="free">A</option>
+			<option value="free">B</option>
+		  </select>
           <button v-if="index === 0 && headNode.children.length > 0"
               class="expand-btn hidden" @click="expanded = !expanded">
             <i :class="[

--- a/src/client/component/truth-tree-branch.ts
+++ b/src/client/component/truth-tree-branch.ts
@@ -227,7 +227,7 @@ export const TruthTreeBranchComponent = defineComponent({
 								selectedNode.isClosedTerminator(),
 						}">
 		  <truth-tree-node :id="id"></truth-tree-node>
-		  <select v-if="tree.nodes[id].children.length > 1" @click.stop="" name="membership" id="membership">
+		  <select v-if="tree.nodes[id].branchAtom != null" @click.stop="" name="membership" id="membership">
 		    <option value="free">A</option>
 			<option value="free">B</option>
 		  </select>
@@ -239,14 +239,15 @@ export const TruthTreeBranchComponent = defineComponent({
             ]"></i>
           </button>
         </li>
-				<template v-if="tree.nodes[id].children.length > 1">
-					<div
-							v-show="expanded"
-							v-for="child in tree.nodes[id].children">
-						<hr class="branch-line"/>
-						<truth-tree-branch :head="child"
-								:ref="addChildBranchRef"></truth-tree-branch>
-					</div>
+		<template v-if="tree.nodes[id].children.length > 1">
+			<div
+				v-show="expanded"
+				v-for="child in tree.nodes[id].children"
+			>
+				<hr class="branch-line"/>
+				<truth-tree-branch :head="child"
+						:ref="addChildBranchRef"></truth-tree-branch>
+			</div>
         </template>
       </template>
       <li v-if="!expanded && headNode.children.length > 0">

--- a/src/client/component/truth-tree-node.ts
+++ b/src/client/component/truth-tree-node.ts
@@ -2,10 +2,10 @@ import {defineComponent} from 'vue';
 import {TruthTree, TruthTreeNode, CorrectnessError} from '../../common/tree';
 
 export function getAtomBranchState(node: TruthTreeNode): string {
-	if (node.branchAtomState === true){
+	if (node.branchAtomState === true) {
 		return ' ⊤';
 	}
-	if (node.branchAtomState === false){
+	if (node.branchAtomState === false) {
 		return ' ⊥';
 	}
 	return '';

--- a/src/client/component/truth-tree-node.ts
+++ b/src/client/component/truth-tree-node.ts
@@ -1,6 +1,15 @@
 import {defineComponent} from 'vue';
 import {TruthTree, TruthTreeNode, CorrectnessError} from '../../common/tree';
 
+export function getAtomBranchState(node: TruthTreeNode): string {
+	if (node.branchAtomState === true){
+		return ' ⊤';
+	}
+	if (node.branchAtomState === false){
+		return ' ⊥';
+	}
+	return '';
+}
 export function getNodeIconClasses(node: TruthTreeNode): string[] {
 	const validity = node.isValid();
 	if (
@@ -49,6 +58,7 @@ export const TruthTreeNodeComponent = defineComponent({
 	},
 	methods: {
 		getNodeIconClasses: getNodeIconClasses,
+		getAtomBranchState: getAtomBranchState,
 		makeSubstitutions(event: FocusEvent) {
 			if (this.node === null) {
 				return;
@@ -97,7 +107,7 @@ export const TruthTreeNodeComponent = defineComponent({
         JSON.stringify(node.universe.map(formula => formula.toString()))
       }}
     </span>
-    <i :class="getNodeIconClasses(node)" :title="node.getFeedback()"></i>
+    <i :class="getNodeIconClasses(node)" :title="node.getFeedback()"> {{getAtomBranchState(node)}} </i>
     <input :id="'node' + this.id" type="text" v-model="node.text"
         @focus="$store.commit('select', {id: id, focus: false})"
         @input="makeSubstitutions($event)"

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -211,9 +211,10 @@ export const instance = vue
 				const tree: TruthTree = this.tree;
 				this.recordState();
 
-				const curNode  = typeof this.selected === 'number' ? this.selected : tree.root;
+				const curNode =
+					typeof this.selected === 'number' ? this.selected : tree.root;
 				const branchAtomState = tree.getNode(curNode)?.branchAtomState;
-				if ( typeof branchAtomState === 'boolean' ) {
+				if (typeof branchAtomState === 'boolean') {
 					this.tree.getNode(curNode).branchAtomState = undefined;
 				}
 
@@ -249,11 +250,11 @@ export const instance = vue
 					typeof this.selected === 'number'
 						? this.selected
 						: tree.rightmostNode()?.id;
-				
+
 				const branchAtom = this.tree.getNode(parentNodeId).branchAtom;
-				
+
 				// if the node is already an atom branch, can't create more branches
-				if (branchAtom != null){
+				if (branchAtom != null) {
 					return alert(
 						'An atom branch is limited to 2 direct sub-branches. Select another node. If this issue persists, please contact an instructor.'
 					);
@@ -292,14 +293,14 @@ export const instance = vue
 
 				const node = this.tree.getNode(parentNodeId);
 				const branchAtom = node.branchAtom;
-				
+
 				// Already has children branch
-				if ( !node.isNodeAtomizable()) {
+				if (!node.isNodeAtomizable()) {
 					return alert(
 						'An atom branch is limited to 2 direct sub-branches. Select another node. If this issue persists, please contact an instructor.'
 					);
 				}
-				
+
 				// create Tautologous branch
 				let newNodeId = tree.addNodeAfter(parentNodeId, true);
 				if (newNodeId === null) {
@@ -308,7 +309,7 @@ export const instance = vue
 					);
 				}
 				this.tree.getNode(newNodeId).branchAtomState = true;
-	
+
 				// create Contradictory branch
 				newNodeId = tree.addNodeAfter(parentNodeId, true);
 				if (newNodeId === null) {

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -115,8 +115,8 @@ export class TruthTreeNode {
 	children: number[] = [];
 
 	// for branching features
-	branchAtom: string|null = null;
-	branchAtomState : boolean| undefined;
+	branchAtom: string | null = null;
+	branchAtomState: boolean | undefined;
 
 	antecedent: number | null = null;
 	decomposition: Set<number> = new Set();

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -42,6 +42,9 @@ export class CorrectnessError {
 			case 'existence_instantiation_length': {
 				return 'Each variable in an existence statement must instantiate a new constant.';
 			}
+			case 'existence_instantiation_violation': {
+				return 'This statement was decomposed multiple times within the same branch.';
+			}
 			case 'open_decomposed': {
 				return 'An open terminator must reference no statements.';
 			}
@@ -887,6 +890,7 @@ export class TruthTreeNode {
 						break;
 					}
 				}
+
 				if (!containedInBranch) {
 					// This node is not decomposed in every non-closed branch
 					if (this.statement instanceof ExistenceStatement) {
@@ -894,6 +898,8 @@ export class TruthTreeNode {
 					} else {
 						leafError = new CorrectnessError('invalid_decomposition');
 					}
+				} else if (this.decomposition.size > this.correctDecomposition!.size) {
+					leafError = new CorrectnessError('existence_instantiation_violation');
 				}
 			}
 

--- a/src/common/tree.ts
+++ b/src/common/tree.ts
@@ -114,6 +114,10 @@ export class TruthTreeNode {
 	parent: number | null = null;
 	children: number[] = [];
 
+	// for branching features
+	branchAtom: string|null = null;
+	branchAtomState : boolean| undefined;
+
 	antecedent: number | null = null;
 	decomposition: Set<number> = new Set();
 	private _correctDecomposition: Set<number> | null = null;
@@ -985,6 +989,19 @@ export class TruthTreeNode {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Is is possible to create two atom branches off this node
+	 * @ returns boolean
+	 */
+	isNodeAtomizable(): boolean {
+		// already an atom branch
+		if (this.branchAtom != null) {
+			return false;
+		}
+		// must be leaf node to be branched
+		return this.children.length === 0;
 	}
 }
 

--- a/userguide.md
+++ b/userguide.md
@@ -146,6 +146,7 @@ Toggle premise|`ctrl+p`
 Add statement before|`ctrl+b`
 Add statement after|`ctrl+a`
 Create branch|`ctrl+shift+b`
+Create atom branch|`ctrl+shift+a`
 Delete statement|`ctrl+d`
 Delete branch|`ctrl+shift+d`
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -52,6 +52,7 @@ html(lang='en')
             button.menu-option(@click='addStatementBefore') Add statement before
             button.menu-option(@click='addStatementAfter') Add statement after
             button.menu-option(@click='createBranch') Create branch
+            button.menu-option(@click='createAtomBranch') Create atom branch
             hr
             button.menu-option(@click='deleteStatement') Delete statement
             button.menu-option(@click='deleteBranch') Delete branch
@@ -164,6 +165,10 @@ html(lang='en')
               td Create branch
               td
                 key-recorder(@on-pressed='createBranch' event='create-branch' :default='["Control", "Shift", "B"]')
+            tr
+              td Create Atom branch
+              td
+                key-recorder(@on-pressed='createAtomBranch' event='create-atom-branch' :default='["Control", "Shift", "A"]')
             tr
               td Delete statement
               td


### PR DESCRIPTION
Add atom branch GUI + Logic
- allow users to create an atom branch
- atom branch will only be created if current node is leaf (not already an atom branch and does not have other branches)
-  added symbols ( ⊤ or ⊥ ) to indicate the atom branch state of a statement
- adding a new statement above the root of an atom branch will shift atom branch state symbol

Before: can't create atom bracnhes

After: see comment for video

