### PR TITLE
Undo ignoring of SQL type definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ config.yml
 logs/*
 !logs/.keep
 
-src/types/
+src/types/*
+!src/types/sql
 
 public/js/index.js
 public/js/index.js.LICENSE.txt

--- a/src/types/sql/public.d.ts
+++ b/src/types/sql/public.d.ts
@@ -1,0 +1,44 @@
+export interface UsersRow {
+	email: string;
+	password: string;
+	first_name: string;
+	last_name: string;
+	rcs_id: string | null;
+	created_at: Date;
+	last_login_at: Date | null;
+	reset_token: string;
+	reset_token_created_at: Date | null;
+}
+
+export interface CoursesRow {
+	name: string;
+	display_name: string | null;
+	created_at: Date;
+}
+
+export interface InstructorsRow {
+	course_name: string;
+	instructor_email: string;
+}
+
+export interface StudentsRow {
+	course_name: string;
+	student_email: string;
+}
+
+export interface AssignmentsRow {
+	name: string;
+	course_name: string;
+	created_at: Date;
+	due_date: Date | null;
+	tree: string;
+}
+
+export interface SubmissionsRow {
+	student_email: string;
+	assignment_name: string;
+	course_name: string;
+	submitted_at: Date;
+	tree: string;
+	correct: boolean;
+}


### PR DESCRIPTION
The type definitions for SQL tables are not generated, so they should be checked in to the repository.